### PR TITLE
build: Add requirement of Python 3.6 or later

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,19 @@ setup(
             'pydotplus'
         ]
     },
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: MIT License",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: Implementation :: CPython",
+    ],
 )


### PR DESCRIPTION
Addresses parts of Issue #16 related to a new `adage` release.

`networkx v2.4+` is required given PR #18 and the last version of `networkx` to support Python 2.7 is [`networkx` `v2.2`](https://pypi.org/project/networkx/2.2/).

So this PR sets a lower bound of Python 3.6 for installation and adds PyPI metadata to make it easier for people to identify supported releases.